### PR TITLE
readTime for blog posts now uses number of words

### DIFF
--- a/src/app/(frontend)/blog/[slug]/page.tsx
+++ b/src/app/(frontend)/blog/[slug]/page.tsx
@@ -31,7 +31,7 @@ async function getPost(params: Props['params']) {
 		groq`*[_type == 'blog.post' && metadata.slug.current == $slug][0]{
 			...,
 			'body': select(_type == 'image' => asset->, body),
-			'readTime': length(pt::text(body)) / 200,
+			'readTime': length(string::split(pt::text(body), " ")) / 200,
 			'headings': body[style in ['h2', 'h3']]{
 				style,
 				'text': pt::text(@)


### PR DESCRIPTION
Previously, readTime was calculating the value based on number of characters instead of words.