### PR TITLE
feat: make template Sanity CLI ready

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-NEXT_PUBLIC_BASE_URL = # https://sanitypress.dev
+NEXT_PUBLIC_BASE_URL="" #https://sanitypress.dev
 
-NEXT_PUBLIC_SANITY_PROJECT_ID = # abcdefgh
-NEXT_PUBLIC_SANITY_DATASET = # production
+NEXT_PUBLIC_SANITY_PROJECT_ID="" #abcdefgh
+NEXT_PUBLIC_SANITY_DATASET="" #production
 
-SANITY_API_READ_TOKEN =	# "Viewer" token from https://sanity.io/manage
+SANITY_API_READ_TOKEN="" #"Viewer" token from https://sanity.io/manage
 
-NEXT_PUBLIC_GITHUB_TOKEN = # used for Reputation blocks
+NEXT_PUBLIC_GITHUB_TOKEN="" #used for Reputation blocks

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,10 @@
+name: Validate Template
+on: push
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate Sanity Template
+        uses: sanity-io/template-validator@v2


### PR DESCRIPTION
👋 We've introduced a way to init a template using the Sanity CLI. In order for this to work the template has to follow a small set of rules, which your template almost does with the exception of `.env.example` that contains spaces around the equal signs, not a part of the [.env spec](https://dotenvx.com/docs/env-file).

In addition we have also introduced some tooling to make sure your template is always valid. A GitHub action will run on every push to validate that the template follows the required conventions. You may read more about this in our WIP documentation, in [this repo's README](https://github.com/sanity-io/template-validator/tree/main).

### Usage

With this change you'll be able to initialize this template by running:
```
npm create sanity@latest -- --template https://github.com/nuotsu/sanitypress
```

or shorthand:

```
npm create sanity@latest -- --template nuotsu/sanitypress
```

### Testing

You can test this out by running this against my fork here:
```
npm create sanity@latest -- --template https://github.com/RostiMelk/sanitypress
```